### PR TITLE
v0.1

### DIFF
--- a/preproc.go
+++ b/preproc.go
@@ -54,7 +54,7 @@ const (
 	mwSO2  = 64.0644
 	mwSO4  = 96.0632
 	mwOH   = 17.008
-	mwH202 = 34.016
+	mwH2O2 = 34.016
 	MWa    = 28.97 // g/mol, molar mass of air
 
 	// Chemical mass conversions [ratios]


### PR DESCRIPTION
Code will now compile properly. Still need to test with dummy data to confirm that it works.

2022-10-20
TR
1.	Found problem where unit conversions were getting a type error as the “sparse” package doesn’t have native multiplication a.	Updated calculation of “alt” to elementwise function (no inverse function in the sparse package) b.	For others, used the format from H2O2 in geoschem.go. For U:
2.	func (w *GEMMACH) U() NextData {
3.	    uufunc := w.read("UU")
4.	    return func() (*sparse.DenseArray, error) {
5.	        UU, err := uufunc()
6.	        if err != nil {
7.	            return nil, err
8.	        }
9.	        //UU = UU.Scale(463.0 / 900.0)
10.	        return UU.ScaleCopy(463.0 / 900.0), nil
11.	    }
12.	}
a.	Updated UU, VV, GLW, TT and alt with these sorts of fixes.
13.	One outstanding in WW (vertical windspeed)
2022-10-14
TR
1.	Changed qrain code to use TR (total precipitation) rather than PC + PR as below
2.	Changed the SOAest function so that it used the built-in “MakeDataPoints” function from sajari’s regression package. Original way was returning an error.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies InMAP to _____."

Example pull request/commit title:
`inmaputil: Add documentation to cmd.go`
-->
